### PR TITLE
Update RAK10701-FieldTester.js to recognise LORIOT as LNS

### DIFF
--- a/RAK10701-FieldTester.js
+++ b/RAK10701-FieldTester.js
@@ -88,6 +88,12 @@ function Decoder(bytes, fPort) {
 			server_type = 3;
 			decoded.is_chirpstack = 1;
 		}
+		//Check if the payload comes from LORIOT
+		else if (typeof (rawPayload.cmd) != "undefined") {
+			console.log("Found LORIOT format");
+			server_type = 4;
+			decoded.is_chirpstack = 1;
+		}	
 		else {
 			console.log("Unknown raw format");
 		}
@@ -136,6 +142,12 @@ function Decoder(bytes, fPort) {
 				case 3:
 					gw_lat[idx] = rawPayload.rxInfo[idx].location.latitude;
 					gw_long[idx] = rawPayload.rxInfo[idx].location.longitude;
+					break;
+
+				// LORIOT
+				case 4:
+					gw_lat[idx] = rawPayload.gws[0].lat;
+					gw_long[idx] = rawPayload.gws[0].lon;
 					break;
 				default:
 					console.log("Unknown LNS");


### PR DESCRIPTION
The changes add a case for the LORIOT network server. I have tested it with the RAKV2 gateway to LORIOT and then to Datacake.